### PR TITLE
Add Single-Assignment C (SaC) compiler image

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -35,6 +35,7 @@ nix-build --out-link result/python images/python.nix
 nix-build --out-link result/raku images/raku.nix
 nix-build --out-link result/ruby images/ruby.nix
 nix-build --out-link result/rust images/rust.nix
+nix-build --out-link result/sac images/sac.nix
 nix-build --out-link result/scala images/scala.nix
 nix-build --out-link result/swift images/swift.nix
 nix-build --out-link result/mercury images/mercury.nix

--- a/images/common/coderunner.nix
+++ b/images/common/coderunner.nix
@@ -5,7 +5,7 @@ let
     builtins.fetchGit {
       url = "git@github.com:glotcode/code-runner.git";
       ref = "main";
-      rev = "c6faaf9c7a7715ea7bfc4603383a04a41679a01b";
+      rev = "7748a4d89c998df3a3e880b9262fb1a5dfde592b";
     };
 
   codeRunner =

--- a/images/sac.nix
+++ b/images/sac.nix
@@ -1,0 +1,28 @@
+let
+  pkgs =
+    import ./common/nixpkgs.nix;
+
+  nix-sac =
+    builtins.fetchGit {
+      url = "https://github.com/hv15/sac-nix";
+      ref = "refs/heads/sac-update";
+      rev = "c8f7ab98cca5d6a628eb15c3dac71a42b6ccdfff";
+    };
+
+  sacpkgs =
+    import nix-sac;
+
+  build_image =
+    import ./common/build_image.nix;
+in
+build_image {
+  pkgs = pkgs;
+  name = "glot/sac";
+  tag = "latest";
+  installedPackages = [
+    pkgs.gcc
+    pkgs.gnused
+    sacpkgs.packages.x86_64-linux.sac2c
+    sacpkgs.packages.x86_64-linux.stdlib
+  ];
+}

--- a/images/sac.nix
+++ b/images/sac.nix
@@ -4,9 +4,9 @@ let
 
   nix-sac =
     builtins.fetchGit {
-      url = "https://github.com/hv15/sac-nix";
-      ref = "refs/heads/sac-update";
-      rev = "c8f7ab98cca5d6a628eb15c3dac71a42b6ccdfff";
+      url = "https://github.com/cxandru/sac-nix";
+      ref = "refs/heads/main";
+      rev = "b5c84342906aef3373d9a6e8b6b6933e1c4ea426";
     };
 
   sacpkgs =


### PR DESCRIPTION
With this PR I'd like to add the build configuration to create a glot image for the SaC compiler.

I've successful built and run an image locally.

The SaC package(s) are being pulled in from https://github.com/cxandru/sac-nix (_currently my fork, see below_), which is setup as a nix flake. I'm using [flake-compat](https://github.com/edolstra/flake-compat) as a shim, which lets me import the package derivation into the image build instructions, I'm not 100% sure if this is OK to do (nix doesn't complain, but it does feel a bit weird). I'm open to any suggestions on how to improve this.

ToDo:
- [x]  update `coderunner.nix` to pull in latest commit (waiting on https://github.com/glotcode/code-runner/pull/1 to be merged).
- [x] update `sac.nix` to pull from https://github.com/cxandru/sac-nix (instead of my fork); waiting on merge