### PR TITLE
Use UID other than 1000

### DIFF
--- a/images/common/build_image.nix
+++ b/images/common/build_image.nix
@@ -39,7 +39,7 @@ pkgs.dockerTools.buildImage {
     ${pkgs.stdenv.shell}
     ${pkgs.dockerTools.shadowSetup}
     ${pkgs.shadow}/bin/groupadd glot
-    ${pkgs.shadow}/bin/useradd -d /home/glot -g glot -s /bin/bash glot
+    ${pkgs.shadow}/bin/useradd -d /home/glot -g glot -s /bin/bash -u 11223 glot
     ${run}
   '';
 


### PR DESCRIPTION
To resolve all the issue from https://github.com/glotcode/docker-run/issues we can specify a fixed UID for the `glot` user which is not 1000. 

By default UID is set to 1000 which also mostly corresponds to the local user UID. Because of this limits are enforced based on the resource usage of the local user + `glot`. Current `nproc` hard limit defaults to 100, and there are usually more than 100 processes running for a typical Linux desktop user. Because of that the container cannot exec any more processes and fails with: `resource temporarily unavailable`.

The UID in the nix definition probably shouldn't be a magic number but I know no nix to help parameterize it :)