### PR TITLE
Add Luau language support

### DIFF
--- a/images/languages/luau.nix
+++ b/images/languages/luau.nix
@@ -1,0 +1,15 @@
+let
+  pkgs =
+    import ../common/nixpkgs.nix;
+
+  build_image =
+    import ../common/build_image.nix;
+in
+build_image {
+  pkgs = pkgs;
+  name = "glot/luau";
+  tag = "latest";
+  installedPackages = [
+    pkgs.luau
+  ];
+}

--- a/src/language.rs
+++ b/src/language.rs
@@ -26,6 +26,7 @@ pub mod javascript;
 pub mod julia;
 pub mod kotlin;
 pub mod lua;
+pub mod luau;
 pub mod mercury;
 pub mod nim;
 pub mod nix;
@@ -81,6 +82,7 @@ pub enum Language {
     Julia,
     Kotlin,
     Lua,
+    Luau,
     Mercury,
     Nim,
     Nix,
@@ -130,6 +132,7 @@ impl Language {
             Self::Julia => Box::new(julia::Julia),
             Self::Kotlin => Box::new(kotlin::Kotlin),
             Self::Lua => Box::new(lua::Lua),
+            Self::Luau => Box::new(luau::Luau),
             Self::Mercury => Box::new(mercury::Mercury),
             Self::Nim => Box::new(nim::Nim),
             Self::Nix => Box::new(nix::Nix),
@@ -194,6 +197,7 @@ pub fn list() -> Vec<Language> {
         Language::Julia,
         Language::Kotlin,
         Language::Lua,
+        Language::Luau,
         Language::Mercury,
         Language::Nim,
         Language::Nix,

--- a/src/language/luau.rs
+++ b/src/language/luau.rs
@@ -1,0 +1,66 @@
+use crate::language::EditorConfig;
+use crate::language::LanguageConfig;
+use crate::language::RunConfig;
+use crate::language::RunInstructions;
+use maud::html;
+use maud::Markup;
+use std::path::PathBuf;
+
+const EXAMPLE_CODE: &str = r#"
+print("Hello World!")
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Luau;
+
+impl LanguageConfig for Luau {
+    fn id(&self) -> String {
+        "luau".to_string()
+    }
+
+    fn name(&self) -> String {
+        "Luau".to_string()
+    }
+
+    fn file_extension(&self) -> String {
+        "luau".to_string()
+    }
+
+    fn editor_config(&self) -> EditorConfig {
+        EditorConfig {
+            default_filename: format!("main.{}", self.file_extension()),
+            mode: "ace/mode/lua".to_string(),
+            use_soft_tabs: true,
+            soft_tab_size: 4,
+            example_code: EXAMPLE_CODE.trim_matches('\n').to_string(),
+        }
+    }
+
+    fn run_config(&self) -> RunConfig {
+        RunConfig {
+            container_image: "glot/luau:latest".to_string(),
+            // Official luau CLI has no --version yet; _VERSION prints "Luau".
+            version_command: "echo 'print(_VERSION)' | luau /dev/stdin".to_string(),
+        }
+    }
+
+    fn logo(&self) -> Markup {
+        html! {
+            svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" preserveAspectRatio="xMidYMid" {
+                path fill="#00A2FF" d="M128 16c61.856 0 112 50.144 112 112s-50.144 112-112 112S16 189.856 16 128 66.144 16 128 16" {
+                }
+                path fill="#003A70" d="M128 56c39.764 0 72 32.236 72 72s-32.236 72-72 72-72-32.236-72-72 32.236-72 72-72" {
+                }
+                path fill="#FFF" d="M176 80c0-17.673-14.327-32-32-32s-32 14.327-32 32 14.327 32 32 32 32-14.327 32-32" {
+                }
+            }
+        }
+    }
+
+    fn run_instructions(&self, main_file: PathBuf, _other_files: Vec<PathBuf>) -> RunInstructions {
+        RunInstructions {
+            build_commands: vec![],
+            run_command: format!("luau {}", main_file.display()),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds **Luau** as a first-class language on glot.io (not a Lua alias). Luau is Roblox’s own runtime ([luau.org](https://luau.org), [luau-lang/luau](https://github.com/luau-lang/luau)).

- **id:** `luau`
- **extension:** `.luau`
- **image:** `glot/luau:latest`
- **run:** `luau {main_file}`
- **editor:** Ace `ace/mode/lua` (no dedicated Ace Luau mode)

The container image uses `pkgs.luau` from this repo’s existing nixpkgs pin (`release-24.05` @ `8f4cb508c33212aa69ae22958d03c0ba9a906f5b`), which already packages official `luau-lang/luau` (currently 0.621).

The official `luau` CLI does not implement `--version` yet (open upstream PR). Version detection uses `_VERSION` via stdin (`echo 'print(_VERSION)' | luau /dev/stdin`), which prints `Luau`.

Wiring mirrors Lua in `src/language.rs`, `src/language/luau.rs`, and `images/languages/luau.nix`.

## Test plan
- [ ] `cargo check` (done locally)
- [ ] Build `images/languages/luau.nix` and confirm `luau` is on PATH
- [ ] Run example `print("Hello World!")` in the container